### PR TITLE
Support for crystal 0.21.1

### DIFF
--- a/samples/00_query_child_of_1.cr
+++ b/samples/00_query_child_of_1.cr
@@ -5,6 +5,6 @@ Crolog.load "#{__DIR__}/sample.pl"
 puts "joe's parents"
 
 # ?- child_of(X, jdoe)
-query child_of(x, :joe) do
+query child_of(x, :joe) {
   puts x
-end
+}

--- a/samples/01_query_child_of_2.cr
+++ b/samples/01_query_child_of_2.cr
@@ -5,6 +5,6 @@ Crolog.load "#{__DIR__}/sample.pl"
 puts "steve's childs"
 
 # ?- child_of(steve, Y)
-query child_of(:steve, y) do
+query child_of(:steve, y) {
   puts y
-end
+}

--- a/samples/02_query_siblings_1.cr
+++ b/samples/02_query_siblings_1.cr
@@ -5,6 +5,6 @@ Crolog.load "#{__DIR__}/sample.pl"
 puts "joe's siblings"
 
 # ?- sibling(jdoe, Y)
-query sibling(:joe, y) do
+query sibling(:joe, y) {
   puts y
-end
+}

--- a/samples/03_yielding.cr
+++ b/samples/03_yielding.cr
@@ -4,9 +4,9 @@ Crolog.load "#{__DIR__}/sample.pl"
 
 
 def humans
-  query human(x) do
+  query human(x) {
     yield x
-  end
+  }
 end
 
 humans do |h|

--- a/samples/10_crystal_defined_facts.cr
+++ b/samples/10_crystal_defined_facts.cr
@@ -8,6 +8,6 @@ rule male(:john)
 rule male(:andy)
 rule male(:carl)
 
-query male(m) do
+query male(m) {
   puts m
-end
+}

--- a/samples/11_crystal_defined_rules.cr
+++ b/samples/11_crystal_defined_rules.cr
@@ -11,14 +11,14 @@ rule male(:carl)
 rule female(:mary)
 rule female(:sandy)
 
-rule human(y) do
+rule human(y) {
   male(y)
-end
+}
 
-rule human(z) do
+rule human(z) {
   female(z)
-end
+}
 
-query human(x) do
+query human(x) {
   puts "#{x} is human"
-end
+}

--- a/samples/12_crystal_defined_complex_rules.cr
+++ b/samples/12_crystal_defined_complex_rules.cr
@@ -14,11 +14,11 @@ rule female(:sandy)
 rule young(:andy)
 rule young(:sandy)
 
-rule boy(y) do
+rule boy(y) {
   male(y)
   young(y)
-end
+}
 
-query boy(x) do
+query boy(x) {
   puts "#{x} is a boy"
-end
+}

--- a/samples/13_crystal_defined_predicates.cr
+++ b/samples/13_crystal_defined_predicates.cr
@@ -8,6 +8,6 @@ rule def mymod(a, b, c)
   c.unify(a.int % b.int)
 end
 
-query mymod(5, 3, x as Int32) do
+query mymod(5, 3, x.as(Int32)) {
   puts "#{x} was returned"
-end
+}

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -10,9 +10,9 @@ describe Crolog do
 
     a = [] of String
 
-    query male(y) do
+    query male(y) {
       a << y.string
-    end
+    }
 
     a.should eq(["john", "andy", "carl"])
   end
@@ -30,15 +30,15 @@ describe Crolog do
     rule young2(:andy)
     rule young2(:sandy)
 
-    rule boy2(y) do
+    rule boy2(y) {
       male2(y)
       young2(y)
-    end
+    }
 
     a = [] of String
-    query boy2(y) do
+    query boy2(y) {
       a << y.string
-    end
+    }
 
     a.should eq(["andy"])
   end
@@ -52,16 +52,16 @@ describe Crolog do
     rule young3(:andy)
     rule happy3(:andy)
 
-    rule boy3(y) do
+    rule boy3(y) {
       male3(y)
       young3(y)
       happy3(y)
-    end
+    }
 
     a = [] of String
-    query boy3(y) do
+    query boy3(y) {
       a << y.string
-    end
+    }
 
     a.should eq(["andy"])
   end
@@ -72,9 +72,9 @@ describe Crolog do
     rule related(:foo, :bar)
 
     a = [] of {String,String}
-    query related(x, y) do
+    query related(x, y) {
       a << {x.string, y.string}
-    end
+    }
 
     a.should eq([{"foo", "bar"}])
   end
@@ -85,14 +85,14 @@ describe Crolog do
 
     rule fact2(:foo, :bar)
 
-    rule related2(x, y) do
+    rule related2(x, y) {
       fact2(y, x)
-    end
+    }
 
     a = [] of {String,String}
-    query related2(j, k) do
+    query related2(j, k) {
       a << {j.string, k.string}
-    end
+    }
 
     a.should eq([{"bar", "foo"}])
   end
@@ -101,9 +101,9 @@ describe Crolog do
     Crolog.load
 
     a = [] of Int32
-    query between(1,4,x as Int32) do
+    query between(1,4,x.as(Int32)) {
       a << x
-    end
+    }
 
     a.should eq([1,2,3,4])
   end
@@ -111,14 +111,14 @@ describe Crolog do
   it "should yield ints" do
     Crolog.load
 
-    rule between2(0, y) do
+    rule between2(0, y) {
       between(1,2,y)
-    end
+    }
 
     a = [] of {Int32,Int32}
-    query between2(x as Int32, y as Int32) do
+    query between2(x.as(Int32), y.as(Int32)) {
       a << {x,y}
-    end
+    }
 
     a.should eq([{0,1},{0,2}])
   end

--- a/src/crolog/macros/export_rule.cr
+++ b/src/crolog/macros/export_rule.cr
@@ -2,9 +2,9 @@ macro export_rule(expr)
   %callback = -> (%t : LibProlog::Term) {
     {% for arg, index in expr.args %}
       # {{arg.name}} = Crolog::Term.new(term_n(%t, {{index}}))
-      {{arg.name}} = Crolog::Term.new((((%t as UInt8*) + {{index}}) as LibProlog::Term))
+      {{arg.name}} = Crolog::Term.new((%t.as(UInt8*) + {{index}}).as(LibProlog::Term))
     {% end %}
     {{expr.body}}
   }
-  LibProlog.register_foreign({{expr.name.stringify}}, {{expr.args.size}}, (%callback.pointer as LibProlog::PLFunction), LibProlog::PL_FA_VARARGS)
+  LibProlog.register_foreign({{expr.name.stringify}}, {{expr.args.size}}, %callback.pointer.as(LibProlog::PLFunction), LibProlog::PL_FA_VARARGS)
 end

--- a/src/crolog/macros/utils.cr
+++ b/src/crolog/macros/utils.cr
@@ -20,5 +20,5 @@ macro translate_clause_to(dest, clause)
 end
 
 macro term_n(term, n)
-  ((({{term}} as UInt8*) + {{n}}) as LibProlog::Term)
+  ({{term}}.as(UInt8*) + {{n}}).as(LibProlog::Term)
 end


### PR DESCRIPTION
This is an update to use `crolog` from latest Crystal version.
All files updates concerns :
- The removal of the deprecated syntax `x as T` (crystal 0.19)
- Blocks passed using `do...end` to a macro argument of type `Call` are not parsed (`Call#block` is `Nop`), so use `{...}` instead.
